### PR TITLE
user token authentication and redirects

### DIFF
--- a/api/api/urls.py
+++ b/api/api/urls.py
@@ -33,4 +33,6 @@ urlpatterns = [
     path("api/users/register", views.register_account_request),
     path("api/users/login", views.login),
     path("api/users/logout", views.logout),
+    path("api/users/dummy", views.dummy),
+    path("api/redirect", views.user_auth_fail),
 ]

--- a/api/holiday_acres_api/views.py
+++ b/api/holiday_acres_api/views.py
@@ -100,14 +100,12 @@ def logout(request):
     body = request.data
     token = body["token"]
     # verify user auth token
-    if (
-        requests.post(
-            (f"http://{user_service_var}/user/verifyToken"),
-            data={"email": body["email"], "token": token},
-            headers={"haec-auth-token": django_secret_key},
-        )
-        == False
-    ):
+    verify = requests.post(
+        (f"http://{user_service_var}/user/verifyToken"),
+        data={"email": body["email"], "token": token},
+        headers={"haec-auth-token": django_secret_key},
+    )
+    if (verify.text) == "false":
         return redirect(user_auth_fail)
     # logout user
     logout = requests.post(
@@ -115,7 +113,8 @@ def logout(request):
         data={"email": body["email"]},
         headers={"haec-auth-token": django_secret_key},
     )
-    response = HttpResponse(logout)
+    user_email = body["email"]
+    response = HttpResponse(f"{user_email} has been successfully logged out")
     response.status_code = 200
     return response
 

--- a/api/holiday_acres_api/views.py
+++ b/api/holiday_acres_api/views.py
@@ -1,5 +1,5 @@
 from django.db.models.fields import NullBooleanField
-from django.shortcuts import render
+from django.shortcuts import render, redirect
 from rest_framework import viewsets
 from django.http import HttpResponse
 from holiday_acres_api.serializers import (
@@ -60,6 +60,9 @@ class BarnSectionViewSet(viewsets.ModelViewSet):
     serializer_class = BarnSectionSerializer
 
 
+# User may access these at any time
+
+
 @api_view(["POST"])
 def register_account_request(request):
     """
@@ -89,16 +92,43 @@ def login(request):
     return JsonResponse({"token": token})
 
 
+# User must be logged in to access these views
+
+
 @api_view(["POST"])
 def logout(request):
     body = request.data
-    response = HttpResponse()
-    response.status_code = 200
+    token = body["token"]
+    # verify user auth token
+    if (
+        requests.post(
+            (f"http://{user_service_var}/user/verifyToken"),
+            data={"email": body["email"], "token": token},
+            headers={"haec-auth-token": django_secret_key},
+        )
+        == False
+    ):
+        return redirect(user_auth_fail)
+    # logout user
     logout = requests.post(
         (f"http://{user_service_var}/user/logout"),
         data={"email": body["email"]},
         headers={"haec-auth-token": django_secret_key},
     )
+    response = HttpResponse(logout)
+    response.status_code = 200
+    return response
+
+
+@api_view(["GET"])
+def dummy(request):
+    return HttpResponse("This is a dummy page")
+
+
+@api_view(["GET"])
+def user_auth_fail(request):
+    print("...redirecting...")
+    response = redirect(dummy)
     return response
 
 

--- a/haec-user-service/src/modules/user/controllers/user.controller.ts
+++ b/haec-user-service/src/modules/user/controllers/user.controller.ts
@@ -83,7 +83,7 @@ export class UserController {
       email: verifyUserTokenDto.email,
       token : verifyUserTokenDto.token,
     });
-    return verifiedUserToken;
+  return verifiedUserToken
   }
 
   @Post('/user/login')

--- a/haec-user-service/src/modules/user/controllers/user.controller.ts
+++ b/haec-user-service/src/modules/user/controllers/user.controller.ts
@@ -19,6 +19,11 @@ type VerifyUserDto = {
   password: string;
 };
 
+type VerifyUserTokenDto = {
+  email: string;
+  token: string;
+};
+
 type LoginUserDto = {
   email: string;
   password: string;
@@ -69,6 +74,16 @@ export class UserController {
       password: verifyUserDto.password,
     });
     return verifiedUser;
+  }
+
+  @Post('/user/verifyToken')
+  @Header('content-type', 'application/json')
+  async verifyUserToken(@Body() verifyUserTokenDto: VerifyUserTokenDto): Promise<boolean> {
+    const verifiedUserToken = await this.userService.verifyUserToken({
+      email: verifyUserTokenDto.email,
+      token : verifyUserTokenDto.token,
+    });
+    return verifiedUserToken;
   }
 
   @Post('/user/login')

--- a/haec-user-service/src/modules/user/services/user.service.ts
+++ b/haec-user-service/src/modules/user/services/user.service.ts
@@ -69,13 +69,11 @@ export class UserService {
         },
       });
       if (await (input.token == user.token)) {
-        console.log(true)
         return true;
       }
     } catch (error) {
       console.error(error);
     }
-    console.log(false)
     return false;
   }
 

--- a/haec-user-service/src/modules/user/services/user.service.ts
+++ b/haec-user-service/src/modules/user/services/user.service.ts
@@ -56,6 +56,29 @@ export class UserService {
     return false;
   }
 
+  // This will either verify the user's token or throw an exception
+  public async verifyUserToken(input: {
+    email: string;
+    token: string;
+  }): Promise<boolean> {
+    let user;
+    try {
+      const user = await this.prisma.user.findUnique({
+        where: {
+          email: input.email,
+        },
+      });
+      if (await (input.token == user.token)) {
+        console.log(true)
+        return true;
+      }
+    } catch (error) {
+      console.error(error);
+    }
+    console.log(false)
+    return false;
+  }
+
   // This will log the user ** IN **
 
   public async loginUser(input: {


### PR DESCRIPTION
This pull request is to:
1) set up `redirects for failed user authentication`, redirecting to the main login page (currently set to a dummy page)
2) put in `if statement` at the beginning of each request that `requires user to be logged in`
3) `validate that user is logged` in through verifyUserToken method in user.service.ts
